### PR TITLE
Fix weird bug when trying to set the port in the bind function from ChromeSocketUdp.m

### DIFF
--- a/src/ios/ChromeSocketsUdp.m
+++ b/src/ios/ChromeSocketsUdp.m
@@ -297,7 +297,14 @@ static NSString* stringFromData(NSData* data) {
 {
     NSNumber* socketId = [command argumentAtIndex:0];
     NSString* address = [command argumentAtIndex:1];
-    NSUInteger port = [[command argumentAtIndex:2] unsignedIntegerValue];
+    NSUInteger port;
+    @try {
+        port =  [portPointer unsignedIntegerValue];
+    } @catch (NSException *exception) {
+        port =  0; //HOTFIX fix bug in cordova 6.0.2
+        // the error thrown is : [NSTaggedPointerString unsignedIntegerValue]: unrecognized selector sent to instance
+        // set the value to 0 if it fails so that the port would be at least set automatically instead of just crashing silently.
+    }
 
     if ([address isEqualToString:@"0.0.0.0"])
         address = nil;

--- a/src/ios/ChromeSocketsUdp.m
+++ b/src/ios/ChromeSocketsUdp.m
@@ -297,6 +297,7 @@ static NSString* stringFromData(NSData* data) {
 {
     NSNumber* socketId = [command argumentAtIndex:0];
     NSString* address = [command argumentAtIndex:1];
+    NSNumber* portPointer = [command argumentAtIndex:2];
     NSUInteger port;
     @try {
         port =  [portPointer unsignedIntegerValue];


### PR DESCRIPTION
I called the bind function with args `[1,"0.0.0.0",0]`
The error thrown is :
```
[NSTaggedPointerString unsignedIntegerValue]: unrecognized selector sent to instance 0xa000000000000301
```
The fix is probably not ideal, but I needed this to work expressly. 
I'm not familiar with objective-C nor IOS development at all.