### PR TITLE
add setBroadcast function to Android and iOS

### DIFF
--- a/sockets.udp.js
+++ b/sockets.udp.js
@@ -100,13 +100,23 @@ exports.getSockets = function(callback) {
     exec(win, null, 'ChromeSocketsUdp', 'getSockets', []);
 };
 
+exports.setBroadcast = function(socketId, enabled, callback) {
+    var win = callback && function() {
+        callback(0);
+    };
+    var fail = callback && function(error) {
+        callback(error.message, callback, error.resultCode);
+    };
+    exec(win, fail, 'ChromeSocketsUdp', 'setBroadcast', [socketId, enabled]);
+};
+
 exports.joinGroup = function(socketId, address, callback) {
     var win = callback && function() {
         callback(0);
     };
     var fail = callback && function(error) {
         callback(error.message, callback, error.resultCode);
-    }
+    };
     exec(win, fail, 'ChromeSocketsUdp', 'joinGroup', [socketId, address]);
 };
 
@@ -116,7 +126,7 @@ exports.leaveGroup = function(socketId, address, callback) {
     };
     var fail = callback && function(error) {
         callback(error.message, callback, error.resultCode);
-    }
+    };
     exec(win, fail, 'ChromeSocketsUdp', 'leaveGroup', [socketId, address]);
 };
 
@@ -126,7 +136,7 @@ exports.setMulticastTimeToLive = function(socketId, ttl, callback) {
     };
     var fail = callback && function(error) {
         callback(error.message, callback, error.resultCode);
-    }
+    };
     exec(win, fail, 'ChromeSocketsUdp', 'setMulticastTimeToLive', [socketId, ttl]);
 };
 
@@ -136,7 +146,7 @@ exports.setMulticastLoopbackMode = function(socketId, enabled, callback) {
     };
     var fail = callback && function(error) {
         callback(error.message, callback, error.resultCode);
-    }
+    };
     exec(win, fail, 'ChromeSocketsUdp', 'setMulticastLoopbackMode', [socketId, enabled]);
 };
 

--- a/src/android/ChromeSocketsUdp.java
+++ b/src/android/ChromeSocketsUdp.java
@@ -72,6 +72,8 @@ public class ChromeSocketsUdp extends CordovaPlugin {
       setMulticastTimeToLive(args, callbackContext);
     } else if ("setMulticastLoopbackMode".equals(action)) {
       setMulticastLoopbackMode(args, callbackContext);
+    } else if ("setBroadcast".equals(action)) {
+      setBroadcast(args, callbackContext);
     } else if ("getJoinedGroups".equals(action)) {
       getJoinedGroups(args, callbackContext);
     } else if ("registerReceiveEvents".equals(action)) {
@@ -318,6 +320,28 @@ public class ChromeSocketsUdp extends CordovaPlugin {
     } catch (IOException e) {
       callbackContext.error(buildErrorInfo(-2, e.getMessage()));
     }
+  }
+
+  private void setBroadcast(CordovaArgs args, final CallbackContext callbackContext)
+    throws JSONException{
+    int socketId = args.getInt(0);
+    boolean enabled = args.getBoolean(1);
+
+    UdpSocket socket = sockets.get(Integer.valueOf(socketId));
+
+    if (socket == null) {
+      Log.e(LOG_TAG, "No socket with socketId " + socketId);
+      callbackContext.error(buildErrorInfo(-4, "Invalid Argument"));
+      return;
+    }
+
+    try {
+      socket.setBroadcast(enabled);
+      callbackContext.success();
+    } catch (IOException e) {
+      callbackContext.error(buildErrorInfo(-2, e.getMessage()));
+    }
+
   }
 
   private void setMulticastLoopbackMode(CordovaArgs args, final CallbackContext callbackContext)
@@ -790,6 +814,10 @@ public class ChromeSocketsUdp extends CordovaPlugin {
       }
 
       multicastSocket.setLoopbackMode(!enabled);
+    }
+
+    void setBroadcast(boolean enabled) throws IOException{
+      channel.socket().setBroadcast(enabled);
     }
 
     public Collection<String> getJoinedGroups() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -181,14 +181,16 @@ exports.defineManualTests = function(rootEl, addButton) {
     var port = 1667;
     chrome.sockets.udp.create(function(createInfo) {
       chrome.sockets.udp.bind(createInfo.socketId, '0.0.0.0', port, function(result) {
-        chrome.sockets.udp.send(createInfo.socketId, data, '255.255.255.255', port, function(result) {
-          if (result < 0) {
-            console.log('send fail: ' + result);
-            chrome.sockets.udp.close(createInfo.socketId);
-          } else {
-            console.log('sendTo: success ' + port);
-            chrome.sockets.udp.close(createInfo.socketId);
-          }
+        chrome.sockets.udp.setBroadcast(createInfo.socketId, true, function(result){
+          chrome.sockets.udp.send(createInfo.socketId, data, '255.255.255.255', port, function(result) {
+            if (result < 0) {
+              console.log('send fail: ' + result);
+              chrome.sockets.udp.close(createInfo.socketId);
+            } else {
+              console.log('sendTo: success ' + port);
+              chrome.sockets.udp.close(createInfo.socketId);
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
Android 7.0 requires a udp socket to have the setBroadcast flag enabled to permit broadcast messages. I updated the  Android and iOS code to have the setBroadcast option. 

I also updated the tests to reflect this new functionality. 

This should be merged rather quickly as Android 7 has been released. 

