### PR TITLE
Fix dependencies to match Cordova's plugin spec

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@
   <repo>https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-sockets-udp.git</repo>
   <issue>https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-sockets-udp/issues</issue>
 
-  <dependency id="cordova-plugin-chrome-apps-common@1" />
+  <dependency id="cordova-plugin-chrome-apps-common" version="^1.0.7" />
 
   <js-module src="sockets.udp.js" name="sockets.udp">
     <clobbers target="chrome.sockets.udp" />
@@ -33,7 +33,7 @@
   </platform>
 
   <platform name="ios">
-    <dependency id="cordova-plugin-chrome-apps-iossocketscommon@1" />
+    <dependency id="cordova-plugin-chrome-apps-iossocketscommon" version="^1.0.2" />
     <source-file src="src/ios/ChromeSocketsUdp.m" />
 
     <config-file target="config.xml" parent="/widget">


### PR DESCRIPTION
According to the Apache Cordova documentation, Id 'plugin@1' not supported for the dependency tag. >=6.0.0 supports version restrictions via the version attribute. >6.0.0 does not support version restrictions, according to the documentation.